### PR TITLE
Add -s param to phpcs execution to show rule

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -32,7 +32,7 @@ done
 # Run phpcs.
 if [ "$FILES" != "" ]; then
   echo "Running Code Sniffer."
-  ./vendor/bin/phpcs --encoding=utf-8 -n -p $FILES
+  ./vendor/bin/phpcs --encoding=utf-8 -s -n -p $FILES
   if [ $? != 0 ]; then
     echo "Fix the error before commit!"
     echo "Run"


### PR DESCRIPTION
This PR adds the -s param when executing PHPCS so that the rule is included when PHPCS fails. Makes it easier to troubleshoot rules.